### PR TITLE
Set up Mocha/Chai and a test db for inventory store unit testing

### DIFF
--- a/inventoryLocalStore/index.js
+++ b/inventoryLocalStore/index.js
@@ -1,0 +1,19 @@
+const { Pool } = require('pg');
+
+class Inventory {
+  constructor(connection) {
+    this.pool = new Pool({
+      connectionString: connection,
+    });
+  }
+
+  getListings(market) {
+    const queryString = `SELECT * FROM listings WHERE market = '${market}'`;
+    return this.pool.query(queryString)
+      .then(result => result.rows)
+      .catch(console.error);
+  }
+}
+
+
+module.exports = Inventory;

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "pg": "^7.3.0"
   },
   "devDependencies": {
+    "chai": "^4.1.2",
+    "eslint": "^4.9.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.7.0",
-    "eslint": "^4.9.0"
+    "mocha": "^4.0.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/test/InventoryStoreSpec.js
+++ b/test/InventoryStoreSpec.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai');
+const { testDbConnection } = require('./db/config');
+const Inventory = require('../inventoryLocalStore/index');
+
+describe('Inventory Store Spec', () => {
+  describe('Listings', () => {
+    it('Should retrieve all listings matching "San Francisco"', (done) => {
+      const db = new Inventory(testDbConnection);
+      db.getListings('San Francisco')
+        .then((listings) => {
+          const notSFListings = listings.filter(listing => listing.market !== 'San Francisco');
+          expect(notSFListings.length).to.equal(0);
+          done();
+        });
+    });
+  });
+});

--- a/test/db/config.js
+++ b/test/db/config.js
@@ -1,0 +1,17 @@
+const config = {
+  host: process.env.PGHOST || 'localhost',
+  dbuser: process.env.PGUSER || 'search_service_test',
+  database: process.env.SEARCH_INVENTORY_TEST_DB || 'inventory_test',
+  password: '',
+  port: process.env.PGPORT || 5432,
+};
+
+module.exports = config;
+
+const {
+  dbuser, password, host, port, database,
+} = config;
+
+module.exports.pgConnection = `postgresql://${dbuser}:${password}@${host}:${port}/postgres`;
+module.exports.dbConnection = `postgresql://${dbuser}:${password}@${host}:${port}/inventory`;
+module.exports.testDbConnection = `postgresql://${dbuser}:${password}@${host}:${port}/${database}`;

--- a/test/db/setup.js
+++ b/test/db/setup.js
@@ -1,0 +1,36 @@
+// This script tears down all existing test database artifacts for the service,
+// sets them up from scratch and populates the tables with a small test data set.
+
+const { Pool } = require('pg');
+const {
+  database, pgConnection, dbConnection, testDbConnection,
+} = require('./config');
+const { createTableQueries, csvExportQueries, csvImportQueries } = require('./setupQueries');
+
+// Connect first to the postgres database to manage inventory_test database drop/create
+let pool = new Pool({
+  connectionString: pgConnection,
+});
+
+// Drop the existing inventory_test database and create a new one
+pool.query(`DROP DATABASE IF EXISTS ${database}`)
+  .then(() => pool.query(`CREATE DATABASE ${database}`))
+  .then(() => pool.end())
+  .then(() => { // Connect to the inventory database to export data for test db
+    pool = new Pool({ connectionString: dbConnection });
+    return pool.query(csvExportQueries.listings);
+  })
+  .then(() => pool.query(csvExportQueries.availability))
+  .then(() => pool.end())
+  .then(() => { // Connect to the inventory_test db to create tables and import data
+    pool = new Pool({ connectionString: testDbConnection });
+    return pool.query(createTableQueries.listings);
+  })
+  .then(() => pool.query(createTableQueries.availability))
+  .then(() => pool.query(csvImportQueries.listings))
+  .then(() => pool.query(csvImportQueries.availability))
+  .then(() => {
+    console.log('TEST: All inventory tables created and seeded with data.');
+  })
+  .catch(console.error)
+  .then(() => pool.end());

--- a/test/db/setupQueries.js
+++ b/test/db/setupQueries.js
@@ -1,0 +1,41 @@
+module.exports.createTableQueries = {
+  listings: `
+    CREATE TABLE listings (
+      id                  SERIAL UNIQUE NOT NULL PRIMARY KEY,
+      name                VARCHAR(140),
+      host_name           VARCHAR(80),
+      market              VARCHAR(80),
+      neighbourhood       VARCHAR(80),
+      room_type           VARCHAR(40),
+      average_rating      FLOAT
+    );
+   `,
+  availability: `
+    CREATE TABLE availability (
+      listing_id          INT NOT NULL REFERENCES listings(id),
+      inventory_date      DATE NOT NULL,
+      price               MONEY
+    );
+  `,
+};
+
+module.exports.csvExportQueries = {
+  listings: `
+    COPY (SELECT * FROM listings WHERE average_rating > 70 FETCH FIRST 5 ROWS ONLY)
+    TO '${__dirname}/listings-test.csv' DELIMITER ',' CSV HEADER;
+  `,
+  availability: `
+    COPY (SELECT * FROM availability WHERE listing_id IN
+      (SELECT id FROM listings WHERE average_rating > 70 FETCH FIRST 5 ROWS ONLY))
+    TO '${__dirname}/availability-test.csv' DELIMITER ',' CSV HEADER;
+  `,
+};
+
+module.exports.csvImportQueries = {
+  listings: `
+    COPY listings FROM '${__dirname}/listings-test.csv' DELIMITER ',' CSV HEADER;
+  `,
+  availability: `
+    COPY availability FROM '${__dirname}/availability-test.csv' DELIMITER ',' CSV HEADER;
+  `,
+};


### PR DESCRIPTION
In a manner consistent with the setup work done for the dev environment, this commit includes a setup script that can be run on the command line to tear down the existing test inventory store and recreate it with a small data sample from the dev inventory store. This setup script only works if the dev environment inventory store has been set up because that is the test data source.