### PR TITLE
Generate simulated search queries and store them in a database

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "^4.16.2",
+    "mongoose": "^4.12.4",
     "pg": "^7.3.0"
   },
   "devDependencies": {

--- a/simulation/db.js
+++ b/simulation/db.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const host = process.env.SEARCH_DATA_HOST || 'localhost';
+const db = process.env.SEARCH_DATA_DB || 'searchData';
+
+mongoose.connect(`mongodb://${host}/${db}`);
+
+module.exports = mongoose;

--- a/simulation/generateSearchQueries.js
+++ b/simulation/generateSearchQueries.js
@@ -1,0 +1,84 @@
+const db = require('./models/searchQueries');
+
+const DATASET_SIZE = 100000;
+const SEARCH_QUERY_ID_START = 5000000;
+const VISIT_ID_START = 1;
+const USER_ID_RANGE = 100000;
+const SEARCH_FREQUENCY_IN_SECONDS = 30;
+const MARKETS = [
+  'San Francisco', 'Seattle', 'Sydney', 'New York', 'Toronto', 'Paris',
+  'London', 'Hong Kong', 'Amsterdam', 'Montreal',
+];
+const MAX_DAYS_UNTIL_TRAVEL = 45;
+const MAX_LENGTH_OF_STAY = 7;
+const ROOM_TYPES = ['any', 'entire home', 'private', 'shared room'];
+
+/* ----- HELPER FUNCTIONS BEGIN ----- */
+
+const incrementIdFrom = (num) => {
+  let startId = num;
+  return () => {
+    startId += 1;
+    return startId;
+  };
+};
+
+const getRandomUser = () =>
+  Math.ceil(Math.random() * USER_ID_RANGE);
+
+const countTimeFrom = (now) => {
+  const timestamp = now;
+  return () => {
+    const timeLapsed = Math.ceil(Math.random() * SEARCH_FREQUENCY_IN_SECONDS);
+    timestamp.setSeconds(timestamp.getSeconds() + timeLapsed);
+    return timestamp;
+  };
+};
+
+const getRandomMarket = () =>
+  MARKETS[Math.floor(Math.random() * MARKETS.length)];
+
+const getRandomDateRange = () => {
+  const daysUntilTravel = Math.ceil(Math.random() * MAX_DAYS_UNTIL_TRAVEL);
+  const lengthOfStay = Math.ceil(Math.random() * MAX_LENGTH_OF_STAY);
+
+  const checkIn = new Date();
+  const checkOut = new Date();
+  checkIn.setDate(checkIn.getDate() + daysUntilTravel);
+  checkOut.setDate(checkOut.getDate() + daysUntilTravel + lengthOfStay);
+
+  return { checkIn, checkOut };
+};
+
+const getRandomRoomType = () =>
+  ROOM_TYPES[Math.floor(Math.random() * ROOM_TYPES.length)];
+
+/* ----- HELPER FUNCTIONS END ----- */
+
+const queries = [];
+const nextSearchQueryId = incrementIdFrom(SEARCH_QUERY_ID_START);
+const nextVisitId = incrementIdFrom(VISIT_ID_START);
+const nextSearchTimestamp = countTimeFrom(new Date());
+for (let i = 0; i < DATASET_SIZE; i += 1) {
+  const { checkIn, checkOut } = getRandomDateRange();
+
+  const query = {
+    searchQueryId: nextSearchQueryId(),
+    timestamp: nextSearchTimestamp(),
+    visitId: nextVisitId(),
+    userId: getRandomUser(),
+    market: getRandomMarket(),
+    checkIn,
+    checkOut,
+    roomType: getRandomRoomType(),
+  };
+
+  queries.push(query);
+}
+
+db.emptySearchQueries()
+  .then(() => db.saveSearchQueries(queries))
+  .then(() => {
+    console.log(`SEARCH QUERY GENERATION: ${queries.length} search queries generated and saved.`);
+  })
+  .catch(console.error);

--- a/simulation/generateSearchQueries.js
+++ b/simulation/generateSearchQueries.js
@@ -41,12 +41,10 @@ const getRandomMarket = () =>
 const getRandomDateRange = () => {
   const daysUntilTravel = Math.ceil(Math.random() * MAX_DAYS_UNTIL_TRAVEL);
   const lengthOfStay = Math.ceil(Math.random() * MAX_LENGTH_OF_STAY);
-
   const checkIn = new Date();
   const checkOut = new Date();
   checkIn.setDate(checkIn.getDate() + daysUntilTravel);
   checkOut.setDate(checkOut.getDate() + daysUntilTravel + lengthOfStay);
-
   return { checkIn, checkOut };
 };
 
@@ -61,7 +59,6 @@ const nextVisitId = incrementIdFrom(VISIT_ID_START);
 const nextSearchTimestamp = countTimeFrom(new Date());
 for (let i = 0; i < DATASET_SIZE; i += 1) {
   const { checkIn, checkOut } = getRandomDateRange();
-
   const query = {
     searchQueryId: nextSearchQueryId(),
     timestamp: nextSearchTimestamp(),
@@ -72,7 +69,6 @@ for (let i = 0; i < DATASET_SIZE; i += 1) {
     checkOut,
     roomType: getRandomRoomType(),
   };
-
   queries.push(query);
 }
 
@@ -80,5 +76,6 @@ db.emptySearchQueries()
   .then(() => db.saveSearchQueries(queries))
   .then(() => {
     console.log(`SEARCH QUERY GENERATION: ${queries.length} search queries generated and saved.`);
+    db.mongoose.connection.close();
   })
   .catch(console.error);

--- a/simulation/models/searchQueries.js
+++ b/simulation/models/searchQueries.js
@@ -1,0 +1,35 @@
+const mongoose = require('./db');
+
+const searchQuerySchema = mongoose.Schema({
+  searchQueryId: Number,
+  timestamp: Date,
+  visitId: Number,
+  userId: Number,
+  market: String,
+  checkIn: Date,
+  checkOut: Date,
+  roomType: String,
+});
+
+searchQuerySchema.index({ searchQueryId: 1 }, { unique: true });
+
+const SearchQuery = mongoose.model('SearchQuery', searchQuerySchema);
+
+const emptySearchQueries = () =>
+  new Promise((resolve, reject) => {
+    SearchQuery.remove({}, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+
+const saveSearchQueries = queries =>
+  new Promise((resolve, reject) => {
+    SearchQuery.insertMany(queries, (err, docs) => {
+      if (err) reject(err);
+      else resolve(docs);
+    });
+  });
+
+module.exports.emptySearchQueries = emptySearchQueries;
+module.exports.saveSearchQueries = saveSearchQueries;

--- a/simulation/models/searchQueries.js
+++ b/simulation/models/searchQueries.js
@@ -1,4 +1,4 @@
-const mongoose = require('./db');
+const mongoose = require('../db');
 
 const searchQuerySchema = mongoose.Schema({
   searchQueryId: Number,

--- a/simulation/models/searchQueries.js
+++ b/simulation/models/searchQueries.js
@@ -31,5 +31,8 @@ const saveSearchQueries = queries =>
     });
   });
 
-module.exports.emptySearchQueries = emptySearchQueries;
-module.exports.saveSearchQueries = saveSearchQueries;
+module.exports = {
+  mongoose,
+  emptySearchQueries,
+  saveSearchQueries,
+};


### PR DESCRIPTION
This commit includes a command line script that can generate and store up to 200K search queries (before encountering a memory heap issue). For this stage of development, these simulated search queries are stored in a Mongo database.