### PR TITLE
Prototype publishing search query messages with Amazon SQS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ bower_components/
 
 # Raw data files used for import during development
 *.csv
+
+# Files with credentials
+server/aws.config.js

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Search service for a model Airbnb system",
   "main": "index.js",
   "dependencies": {
+    "aws-sdk": "^2.141.0",
     "elasticsearch": "^13.3.1",
     "express": "^4.16.2",
     "mongoose": "^4.12.4",
-    "pg": "^7.3.0"
+    "pg": "^7.3.0",
+    "uniqid": "^4.1.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/server/amazonSQS.js
+++ b/server/amazonSQS.js
@@ -1,0 +1,24 @@
+const AWS = require('aws-sdk');
+const config = require('./aws.config');
+
+AWS.config.update({
+  accessKeyId: process.env.SQS_ACCESS_KEY || config.accessKey,
+  secretAccessKey: process.env.SQS_SECRET_KEY || config.secretKey,
+});
+
+const sqs = new AWS.SQS({ region: process.env.SQS_REGION || config.region });
+
+const queues = {
+  searchQuery: 'https://sqs.us-west-1.amazonaws.com/766255721592/modelAirbnb-searchQueries',
+};
+
+module.exports.publish = (message, name) => {
+  const sqsParams = {
+    MessageBody: JSON.stringify(message),
+    QueueUrl: queues[name],
+  };
+
+  sqs.sendMessage(sqsParams, (err) => {
+    if (err) throw err;
+  });
+};

--- a/server/httpSearch.js
+++ b/server/httpSearch.js
@@ -1,4 +1,6 @@
 const express = require('express');
+const uniqid = require('uniqid');
+const messageBus = require('./amazonSQS');
 
 const getStayBookendNights = (params) => {
   const lastNight = new Date(params.checkout);
@@ -6,10 +8,30 @@ const getStayBookendNights = (params) => {
   return { firstNight: params.checkin, lastNight: lastNight.toJSON().split('T')[0] };
 };
 
+const searchQueryMessage = (params) => {
+  const {
+    visitId, userId, market, checkin, checkout, roomType,
+  } = params;
+
+  const searchQueryId = uniqid('search-');
+  const messagePayload = {
+    searchQueryId,
+    timestamp: new Date(),
+    visitId,
+    userId,
+    market,
+    checkIn: new Date(checkin),
+    checkOut: new Date(checkout),
+    roomType: roomType || 'any',
+  };
+
+  return { searchQueryId, messagePayload };
+};
+
 const createService = (inventoryStore) => {
   const service = express();
 
-  service.get('/search/:market', (req, res) => {
+  service.get('/search/:visitId/:userId/:market', (req, res) => {
     const { market } = req.params;
     inventoryStore.getListings(market)
       .then((listings) => {
@@ -18,7 +40,7 @@ const createService = (inventoryStore) => {
       .catch(console.error);
   });
 
-  service.get('/search/:market/:limit', (req, res) => {
+  service.get('/search/:visitId/:userId/:market/:limit', (req, res) => {
     const { market, limit } = req.params;
     inventoryStore.getListings(market, limit)
       .then((listings) => {
@@ -27,7 +49,7 @@ const createService = (inventoryStore) => {
       .catch(console.error);
   });
 
-  service.get('/search/:market/:checkin/:checkout', (req, res) => {
+  service.get('/search/:visitId/:userId/:market/:checkin/:checkout', (req, res) => {
     const { market } = req.params;
     const { firstNight, lastNight } = getStayBookendNights(req.params);
     inventoryStore.getAvailableListings(market, firstNight, lastNight)
@@ -37,14 +59,16 @@ const createService = (inventoryStore) => {
       .catch(console.error);
   });
 
-  service.get('/search/:market/:checkin/:checkout/:limit', (req, res) => {
+  service.get('/search/:visitId/:userId/:market/:checkin/:checkout/:limit', (req, res) => {
     const { market, limit } = req.params;
     const { firstNight, lastNight } = getStayBookendNights(req.params);
+    const { messagePayload } = searchQueryMessage(req.params);
     inventoryStore.getAvailableListings(market, firstNight, lastNight, limit)
       .then((listings) => {
         res.status(200).send(listings);
       })
       .catch(console.error);
+    messageBus.publish({ payload: messagePayload }, 'searchQuery');
   });
 
   return service;

--- a/test/ServerSpec.js
+++ b/test/ServerSpec.js
@@ -7,6 +7,8 @@ const service = require('../server/httpSearch')(testInventoryStore);
 const request = require('supertest');
 
 const PORT = 4569;
+const TEST_VISIT_ID = '000';
+const TEST_USER_ID = '000000';
 
 describe('Server Spec', () => {
   let server;
@@ -19,10 +21,10 @@ describe('Server Spec', () => {
     server.close();
   });
 
-  describe('/search/:market', () => {
+  describe('Search by market', () => {
     it('Should retrieve all listings matching "San Francisco"', (done) => {
       request(server)
-        .get('/search/San%20Francisco')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -34,7 +36,7 @@ describe('Server Spec', () => {
 
     it('Should retrieve 0 listings matching "Fakecity"', (done) => {
       request(server)
-        .get('/search/Fakecity')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/Fakecity`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -42,12 +44,10 @@ describe('Server Spec', () => {
         })
         .end(done);
     });
-  });
 
-  describe('/search/:market/:limit', () => {
     it('Should retrieve top 2 listings matching "San Francisco"', (done) => {
       request(server)
-        .get('/search/San%20Francisco/2')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -58,7 +58,7 @@ describe('Server Spec', () => {
 
     it('Should retrieve all 5 listings matching "San Francisco" when top 100 is requested', (done) => {
       request(server)
-        .get('/search/San%20Francisco/100')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/100`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -68,10 +68,10 @@ describe('Server Spec', () => {
     });
   });
 
-  describe('/search/:market/:checkin/:checkout', () => {
+  describe('Search by market and date range', () => {
     it('Should retrieve all San Francisco listings available for checkin 2017-11-12 checkout 2017-11-13', (done) => {
       request(server)
-        .get('/search/San%20Francisco/2017-11-12/2017-11-13')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2017-11-12/2017-11-13`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -84,7 +84,7 @@ describe('Server Spec', () => {
 
     it('Should retrieve no San Francisco listings available for checkin 2017-10-02 checkout 2017-10-03', (done) => {
       request(server)
-        .get('/search/San%20Francisco/2017-10-02/2017-10-03')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2017-10-02/2017-10-03`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -99,7 +99,7 @@ describe('Server Spec', () => {
         '2017-10-19': 0, '2017-10-20': 0, '2017-10-21': 0, '2017-10-22': 0, '2017-10-23': 0,
       };
       request(server)
-        .get('/search/San%20Francisco/2017-10-19/2017-10-24')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2017-10-19/2017-10-24`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -113,13 +113,11 @@ describe('Server Spec', () => {
         })
         .end(done);
     });
-  });
 
-  describe('/search/:market/:checkin/:checkout/:limit', () => {
     it('Should retrieve 2 of 4 San Francisco listings available for checkin 2017-11-12 checkout 2017-11-13', (done) => {
       const availableListings = new Set();
       request(server)
-        .get('/search/San%20Francisco/2017-11-12/2017-11-13/2')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2017-11-12/2017-11-13/2`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -133,7 +131,7 @@ describe('Server Spec', () => {
 
     it('Should retrieve all 4 San Francisco listings available for checkin 2017-11-12 checkout 2017-11-13 when top 100 is requested', (done) => {
       request(server)
-        .get('/search/San%20Francisco/2017-11-12/2017-11-13/100')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2017-11-12/2017-11-13/100`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -145,7 +143,7 @@ describe('Server Spec', () => {
     it('Should retrieve 1 of 2 San Francisco listings available for checkin 2017-11-10 checkout 2017-11-13', (done) => {
       const stayDates = { '2017-11-10': 0, '2017-11-11': 0, '2017-11-12': 0 };
       request(server)
-        .get('/search/San%20Francisco/2017-11-10/2017-11-13/1')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2017-11-10/2017-11-13/1`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {
@@ -163,7 +161,7 @@ describe('Server Spec', () => {
       const availableListings = new Set();
       const stayDates = { '2017-11-10': 0, '2017-11-11': 0, '2017-11-12': 0 };
       request(server)
-        .get('/search/San%20Francisco/2017-11-10/2017-11-13/100')
+        .get(`/search/${TEST_VISIT_ID}/${TEST_USER_ID}/San%20Francisco/2017-11-10/2017-11-13/100`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((response) => {


### PR DESCRIPTION
This was prototyped using the '/search/:market/:checkin/:checkout/:limit' route. Message publishing has not been added to the other routes yet -- this will come in a subsequent PR.