### PR TITLE
Add indexes to inventory db to speed up availability query

### DIFF
--- a/inventoryLocalStore/schema.sql
+++ b/inventoryLocalStore/schema.sql
@@ -11,11 +11,16 @@ CREATE TABLE listings (
   average_rating      FLOAT
 );
 
+CREATE INDEX listings_market ON listings (market);
+
 CREATE TABLE availability (
   listing_id          INT NOT NULL REFERENCES listings(id),
   inventory_date      DATE NOT NULL,
   price               MONEY
 );
+
+CREATE INDEX availability_inventory_date ON availability (inventory_date);
+CREATE INDEX availability_listing_id_inventory_date ON availability (listing_id, inventory_date);
 
 CREATE TABLE amenities (
   id                  SERIAL UNIQUE NOT NULL PRIMARY KEY,

--- a/setup/inventoryLocalStore/dbQueries.js
+++ b/setup/inventoryLocalStore/dbQueries.js
@@ -47,6 +47,12 @@ module.exports.createTable = {
   `,
 };
 
+module.exports.createIndex = {
+  listingsMarket: 'CREATE INDEX listings_market ON listings (market);',
+  availabilityInventoryDate: 'CREATE INDEX availability_inventory_date ON availability (inventory_date);',
+  availabilityListingIdInventoryDate: 'CREATE INDEX availability_listing_id_inventory_date ON availability (listing_id, inventory_date);',
+};
+
 const DATA_DIR = `${__dirname}/data`;
 
 module.exports.csvImport = {

--- a/setup/inventoryLocalStore/dbSetup.js
+++ b/setup/inventoryLocalStore/dbSetup.js
@@ -3,7 +3,7 @@
 const { Pool } = require('pg');
 const { database, pgConnection, dbConnection } = require('../../inventoryLocalStore/config');
 const {
-  createTable, csvImport, addSeedData, dropTable,
+  createTable, csvImport, addSeedData, dropTable, createIndex,
 } = require('./dbQueries');
 
 const markets = [
@@ -56,7 +56,10 @@ for (let i = 0; i < markets.length; i += 1) {
     .catch(console.error);
 }
 
-async.then(() => {
-  console.log('INVENTORY STORE: All tables created and seeded with data.');
-})
+async.then(() => pool.query(createIndex.listingsMarket))
+  .then(() => pool.query(createIndex.availabilityInventoryDate))
+  .then(() => pool.query(createIndex.availabilityListingIdInventoryDate))
+  .then(() => {
+    console.log('INVENTORY STORE: All tables created and seeded with data.');
+  })
   .then(() => pool.end());


### PR DESCRIPTION
Creating indexes on the listings and availability table reduced the run time of the availability query from almost 7 seconds to around 1.5 seconds (according to pg's explain analyze). This is still not fast enough for a search service but it is still a big improvement. Therefore, this commit updates the schema.sql file and the setup script to create these indexes as part of setting up the db.