### PR TITLE
Remove checkin/checkout in Search Event messages for dateless searches

### DIFF
--- a/server/messageBus.js
+++ b/server/messageBus.js
@@ -15,14 +15,17 @@ module.exports.publishSearchEvent
         visitId,
         userId,
         market,
-        checkIn: checkin || 'dateless',
-        checkOut: checkout || 'dateless',
         roomType: roomType || 'any',
         limit: limit || 'no limit',
       },
       searchResults,
       responseTimeline,
     };
+
+    if (checkin && checkout) {
+      messagePayload.searchRequest.checkIn = checkin;
+      messagePayload.searchRequest.checkOut = checkout;
+    }
 
     sqs.publish({ topic: TOPIC_SEARCH, payload: messagePayload });
   };


### PR DESCRIPTION
Per discussion with @tylertruong, checkin and checkout properties will not be included in the search event messages so that unnecessary complexity isn't added to the Recommendation service, one of the consumers of the messages.