### PR TITLE
Publish only SF search events to external subscribers

### DIFF
--- a/messageBus/amazonSQS.js
+++ b/messageBus/amazonSQS.js
@@ -10,11 +10,9 @@ const sqs = new AWS.SQS({ region: process.env.SQS_REGION || config.region });
 
 const MAX_NUMBER_OF_MESSAGES_TO_RECEIVE = 10;
 const MESSAGE_VISIBILITY_TIMEOUT = 10;
-const subscribers = [
-  config.queue,
-];
 
-module.exports.publish = (message) => {
+module.exports.publish = (message, publishToAll) => {
+  const subscribers = [config.queue].concat(publishToAll ? config.subscribers : []);
   subscribers.forEach((subscriber) => {
     const sqsParams = {
       QueueUrl: subscriber,

--- a/messageBus/index.js
+++ b/messageBus/index.js
@@ -1,6 +1,7 @@
 const sqs = require('./amazonSQS');
 
 const TOPIC_SEARCH = 'search';
+const MVP_MARKET = 'San Francisco';
 
 const publishSearchEvent = (searchEventId, params, results, timeline) => {
   const {
@@ -25,7 +26,7 @@ const publishSearchEvent = (searchEventId, params, results, timeline) => {
     messagePayload.request.checkOut = checkout;
   }
 
-  sqs.publish({ topic: TOPIC_SEARCH, payload: messagePayload });
+  sqs.publish({ topic: TOPIC_SEARCH, payload: messagePayload }, market === MVP_MARKET);
 };
 
 const checkForMessages = topic =>


### PR DESCRIPTION
Non-SF search events will only be published to the queue used by the Search micro-service.