### PR TITLE
Parse date (in nightly prices) to not show time in published messages

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -42,7 +42,7 @@ module.exports.getListings = dbResults =>
     } = listing;
 
     const nightlyPrices = dates.map((date, i) => (
-      { date, price: prices[i] }
+      { date: date.toISOString().split('T')[0], price: prices[i] }
     ));
 
     return {


### PR DESCRIPTION
This is in response to a request from Inventory.