### PR TITLE
Integrate scoring data from Recommendations to sort listings

### DIFF
--- a/messageBus/index.js
+++ b/messageBus/index.js
@@ -9,7 +9,7 @@ module.exports.recommendationInbox = sqs.queues.recommendationInbox;
 
 module.exports.publishSearchEvent = (searchEventId, params, results, timeline) => {
   const {
-    userId, market, checkin, checkout, roomType, limit,
+    userId, market, checkIn, checkOut, roomType, limit,
   } = params;
 
   const messagePayload = {
@@ -24,9 +24,9 @@ module.exports.publishSearchEvent = (searchEventId, params, results, timeline) =
     results,
     timeline,
   };
-  if (checkin && checkout) {
-    messagePayload.request.checkIn = checkin;
-    messagePayload.request.checkOut = checkout;
+  if (checkIn && checkOut) {
+    messagePayload.request.checkIn = checkIn;
+    messagePayload.request.checkOut = checkOut;
   }
 
   sqs.publish({ topic: TOPIC_SEARCH, payload: messagePayload }, market === MVP_MARKET);

--- a/recommendationStore/model.js
+++ b/recommendationStore/model.js
@@ -19,17 +19,18 @@ inventoryScoringSchema.index(keys, { unique: true });
 
 const inventoryScoring = mongoose.model('InventoryScoring', inventoryScoringSchema);
 
-module.exports.updateInventoryScoring = (doc) => {
-  const filter = {
-    'rules.market': doc.rules.market,
-    'rules.checkIn': doc.rules.checkIn,
-    'rules.checkOut': doc.rules.checkOut,
-    'rules.roomType': doc.rules.roomType,
-  };
-  return new Promise((resolve, reject) => {
+module.exports.updateInventoryScoring = (filter, doc) =>
+  new Promise((resolve, reject) => {
     inventoryScoring.update(filter, doc, { upsert: true }, (err) => {
       if (err) reject(err);
       else resolve();
     });
   });
-};
+
+module.exports.getInventoryScoring = filter =>
+  new Promise((resolve, reject) => {
+    inventoryScoring.find(filter, (err, doc) => {
+      if (err) reject(err);
+      else resolve(doc);
+    });
+  });

--- a/recommendationStore/model.js
+++ b/recommendationStore/model.js
@@ -16,8 +16,8 @@ inventoryScoringSchema.index(keys, { unique: true });
 
 const inventoryScoring = mongoose.model('InventoryScoring', inventoryScoringSchema);
 
-const createFilter = (doc) => {
-  const { market, checkIn, checkOut } = doc.rules;
+const createFilter = (rule) => {
+  const { market, checkIn, checkOut } = rule;
   return {
     'rules.market': market,
     'rules.checkIn': checkIn,
@@ -25,9 +25,9 @@ const createFilter = (doc) => {
   };
 };
 
-module.exports.updateInventoryScoring = doc =>
+module.exports.updateInventoryScoring = (rule, doc) =>
   new Promise((resolve, reject) => {
-    inventoryScoring.update(createFilter(doc), doc, { upsert: true }, (err) => {
+    inventoryScoring.update(createFilter(rule), doc, { upsert: true }, (err) => {
       if (err) reject(err);
       else resolve();
     });

--- a/recommendationStore/model.js
+++ b/recommendationStore/model.js
@@ -5,31 +5,37 @@ const inventoryScoringSchema = mongoose.Schema({
     market: String,
     checkIn: String,
     checkOut: String,
-    roomType: String,
   },
   coefficients: {
     price: Number,
   },
 });
 
-const keys = {
-  'rules.market': 1, 'rules.checkIn': 1, 'rules.checkOut': 1, 'rules.roomType': 1,
-};
+const keys = { 'rules.market': 1, 'rules.checkIn': 1, 'rules.checkOut': 1 };
 inventoryScoringSchema.index(keys, { unique: true });
 
 const inventoryScoring = mongoose.model('InventoryScoring', inventoryScoringSchema);
 
-module.exports.updateInventoryScoring = (filter, doc) =>
+const createFilter = (doc) => {
+  const { market, checkIn, checkOut } = doc.rules;
+  return {
+    'rules.market': market,
+    'rules.checkIn': checkIn,
+    'rules.checkOut': checkOut,
+  };
+};
+
+module.exports.updateInventoryScoring = doc =>
   new Promise((resolve, reject) => {
-    inventoryScoring.update(filter, doc, { upsert: true }, (err) => {
+    inventoryScoring.update(createFilter(doc), doc, { upsert: true }, (err) => {
       if (err) reject(err);
       else resolve();
     });
   });
 
-module.exports.getInventoryScoring = filter =>
+module.exports.getInventoryScoring = rule =>
   new Promise((resolve, reject) => {
-    inventoryScoring.find(filter, (err, doc) => {
+    inventoryScoring.find(createFilter(rule), (err, doc) => {
       if (err) reject(err);
       else resolve(doc);
     });

--- a/recommendationStore/recommendations.worker.js
+++ b/recommendationStore/recommendations.worker.js
@@ -4,6 +4,18 @@ const db = require('./model');
 const MAX_WORKERS = process.argv[2] || 1;
 const SLEEP_MS = 2000;
 
+const createFilter = (rules) => {
+  const {
+    market, checkIn, checkOut, roomType,
+  } = rules;
+  return {
+    'rules.market': market,
+    'rules.checkIn': checkIn,
+    'rules.checkOut': checkOut,
+    'rules.roomType': roomType,
+  };
+};
+
 const processRecommendationsEvents = (id) => {
   const taskTimeStart = Date.now();
   let messages;
@@ -18,7 +30,8 @@ const processRecommendationsEvents = (id) => {
           },
         };
       });
-      const docUpserts = messages.map(db.updateInventoryScoring);
+      const docUpserts = messages.map(message =>
+        db.updateInventoryScoring(createFilter(message.rules), message));
       return Promise.all(docUpserts);
     })
     .then(() => {

--- a/recommendationStore/recommendations.worker.js
+++ b/recommendationStore/recommendations.worker.js
@@ -18,7 +18,8 @@ const processRecommendationsEvents = (id) => {
           },
         };
       });
-      const docUpserts = messages.map(db.updateInventoryScoring);
+      const docUpserts = messages.map(message =>
+        db.updateInventoryScoring(message(message.rules), message));
       return Promise.all(docUpserts);
     })
     .then(() => {

--- a/recommendationStore/recommendations.worker.js
+++ b/recommendationStore/recommendations.worker.js
@@ -4,18 +4,6 @@ const db = require('./model');
 const MAX_WORKERS = process.argv[2] || 1;
 const SLEEP_MS = 2000;
 
-const createFilter = (rules) => {
-  const {
-    market, checkIn, checkOut, roomType,
-  } = rules;
-  return {
-    'rules.market': market,
-    'rules.checkIn': checkIn,
-    'rules.checkOut': checkOut,
-    'rules.roomType': roomType,
-  };
-};
-
 const processRecommendationsEvents = (id) => {
   const taskTimeStart = Date.now();
   let messages;
@@ -30,8 +18,7 @@ const processRecommendationsEvents = (id) => {
           },
         };
       });
-      const docUpserts = messages.map(message =>
-        db.updateInventoryScoring(createFilter(message.rules), message));
+      const docUpserts = messages.map(db.updateInventoryScoring);
       return Promise.all(docUpserts);
     })
     .then(() => {

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -23,7 +23,7 @@ class OperationLog {
     };
   }
 
-  add(operations) {
+  startTimer(operations) {
     operations.forEach((operation) => {
       this.timeline[operation] = { timestamp: backDateSearchTimestamp(), msTimeLapsed: 0 };
     });

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -57,7 +57,7 @@ module.exports.sortListings = (inventory, scoring) => {
       id, name, host_name, market, neighbourhood, room_type, average_rating, dates, prices,
     } = listing;
 
-    const nightlyPrices = dates.map((date, i) => ({ date, price: prices[i] }));
+    const nightlyPrices = dates.map((date, i) => ({ date: date.toISOString().split('T')[0], price: prices[i] }));
     const averagePrice = nightlyPrices.reduce((sum, price) => sum + price) / nightlyPrices.length;
 
     return {

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -57,9 +57,8 @@ module.exports.sortListings = (inventory, scoring) => {
       id, name, host_name, market, neighbourhood, room_type, average_rating, dates, prices,
     } = listing;
 
-    const nightlyPrices = dates.map((date, i) => (
-      { date: date.toISOString().split('T')[0], price: prices[i] }
-    ));
+    const nightlyPrices = dates.map((date, i) => ({ date, price: prices[i] }));
+    const averagePrice = nightlyPrices.reduce((sum, price) => sum + price) / nightlyPrices.length;
 
     return {
       listingId: id,

--- a/server/httpSearch.js
+++ b/server/httpSearch.js
@@ -12,13 +12,13 @@ const createService = (inventoryStore) => {
 
   service.get('/search/:userId/:market/:checkIn/:checkOut/:limit*?', (req, res) => {
     const log = new OperationLog(HTTP_REQUEST);
-    log.add([FETCH_LISTINGS, FETCH_SCORING]);
+    log.startTimer([FETCH_LISTINGS, FETCH_SCORING]);
     Promise.all([
       fetchListings(req.params, inventoryStore, log),
       fetchCoefficients(req.params, recommendationStore, log)
     ])
       .then(([inventory, scoring]) => {
-        log.add([SORT_LISTINGS]);
+        log.startTimer([SORT_LISTINGS]);
         const listings = sortListings(inventory, scoring);
         log.stopTimer([SORT_LISTINGS]);
         res.status(200).send(listings);


### PR DESCRIPTION
Messages from the Recommendations queue are upserted into a non-relational DB so that the scoring rules and coefficients can be looked up during a search request and applied to the sorting of the search results. A non-relational DB was chosen for its schema flexibility; in particular, rules can take on various shapes and additional coefficients can be added without needing a schema change. This commit also includes a refactor of the homebrew-ed logging solution (Operation Log class) so that time lapsed can be logged for operations happening in parallel (like fetching listings and fetching scoring coefficients). Note that the MVP version of Recommendations provides only a scoring coefficient for price.